### PR TITLE
Notificar cambios en workspaceXml - Fixes #40

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -52,7 +52,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       document.querySelector('#print_xmlbtn').addEventListener('click', function() {
-        console.log(blocklyElement.get('workspaceXML'));
+        console.log(blocklyElement.get('workspaceXml'));
       });
     </script>
 

--- a/gs-element-blockly.html
+++ b/gs-element-blockly.html
@@ -116,9 +116,9 @@ Example:
         },
 
         /*
-         * `workspaceXML` Código XML de los bloques en el workspace.
+         * `workspaceXml` Código XML de los bloques en el workspace.
          */
-        workspaceXML: {
+        workspaceXml: {
           type: String,
           observer: '_onWorkspaceUpdate'
         },
@@ -342,13 +342,13 @@ Example:
       _onBlocklyWorkspaceUpdate: function () {
         let xml = Blockly.Xml.workspaceToDom(this.workspace);
         this._blocklyWorkspaceXML = Blockly.Xml.domToText(xml);
-        this.workspaceXML = this._blocklyWorkspaceXML;
+        this.workspaceXml = this._blocklyWorkspaceXML;
       },
 
       _onWorkspaceUpdate: function () {
-        if(this.workspaceXML != this._blocklyWorkspaceXML) {
+        if(this.workspaceXml != this._blocklyWorkspaceXML) {
           this.workspace.clear();
-          let dom = Blockly.Xml.textToDom(this.workspaceXML);
+          let dom = Blockly.Xml.textToDom(this.workspaceXml);
           Blockly.Xml.domToWorkspace(dom, this.workspace);
         }
       },
@@ -358,7 +358,7 @@ Example:
        */
       resetWorkspace: function() {
         let xmlInicial = '<xml xmlns="http://www.w3.org/1999/xhtml"><block type="Program" x="30" y="30"></block></xml>';
-        this.workspaceXML = xmlInicial;
+        this.workspaceXml = xmlInicial;
       },
 
       /**

--- a/gs-element-blockly.html
+++ b/gs-element-blockly.html
@@ -120,7 +120,8 @@ Example:
          */
         workspaceXml: {
           type: String,
-          observer: '_onWorkspaceUpdate'
+          observer: '_onWorkspaceUpdate',
+          notify: true
         },
 
         /*

--- a/test/generator_test.js
+++ b/test/generator_test.js
@@ -86,7 +86,7 @@ program {
 test('Procedimiento primitivo', function() {
   let element = document.getElementById("gseb");
   element.primitiveProcedures = ['Poner_FloresAl_'];
-  element.workspaceXML = `<xml xmlns="http://www.w3.org/1999/xhtml"><block type="Program" deletable="false" movable="false" editable="false" x="30" y="30"><statement name="program"><block type="Poner_FloresAl_"><value name="arg1"><block type="math_number"><field name="NUM">4</field></block></value><value name="arg2"><block type="Este"></block></value></block></statement></block></xml>`;
+  element.workspaceXml = `<xml xmlns="http://www.w3.org/1999/xhtml"><block type="Program" deletable="false" movable="false" editable="false" x="30" y="30"><statement name="program"><block type="Poner_FloresAl_"><value name="arg1"><block type="math_number"><field name="NUM">4</field></block></value><value name="arg2"><block type="Este"></block></value></block></statement></block></xml>`;
   assert.equal(element.generateCode(), `program {
   Poner_FloresAl_(4, Este)
 }`);

--- a/test/helper.js
+++ b/test/helper.js
@@ -4,7 +4,7 @@
  function gsTestCode(name, xml, code) {
    test(name, function() {
      let element = document.getElementById("gseb");
-     element.workspaceXML = xml;
+     element.workspaceXml = xml;
      assert.equal(element.generateCode(), code);
    });
  }


### PR DESCRIPTION
@miguelgarcia no estaba notificando porque por default los bindings de polymer no son bidireccionales a menos que le pongas notify true.

Aproveché para renombrarla a `workspaceXml` ya que no sabía cómo polymer iba a convertir `workspaceXML` a dash-case al momento de usarla.