### PR TITLE
Cambio formato de comentarios

### DIFF
--- a/js/gobstones-language-generator.js
+++ b/js/gobstones-language-generator.js
@@ -151,9 +151,9 @@ Blockly.GobstonesLanguage.scrub_ = function (block, code) {
 		if (comment) {
 			if (block.getProcedureDef) {
 				// Use a comment block for function comments.
-				commentCode += '/*\n' +
-					Blockly.GobstonesLanguage.prefixLines(comment + '\n', ' * ') +
-					' */\n';
+				commentCode += '//\n' +
+					Blockly.GobstonesLanguage.prefixLines(comment + '\n', '//') +
+					'//\n';
 			} else {
 				commentCode += Blockly.GobstonesLanguage.prefixLines(comment + '\n', '// ');
 			}

--- a/js/gobstones-language-generator.js
+++ b/js/gobstones-language-generator.js
@@ -151,7 +151,7 @@ Blockly.GobstonesLanguage.scrub_ = function (block, code) {
 		if (comment) {
 			if (block.getProcedureDef) {
 				// Use a comment block for function comments.
-				commentCode += '/**\n' +
+				commentCode += '/*\n' +
 					Blockly.GobstonesLanguage.prefixLines(comment + '\n', ' * ') +
 					' */\n';
 			} else {

--- a/test/generator_test.js
+++ b/test/generator_test.js
@@ -40,7 +40,7 @@ suite('gs-element-blockly_generator', function() {
 
   gsTestCode('Procedimiento',
   '<xml xmlns="http://www.w3.org/1999/xhtml"><block type="procedures_defnoreturn"><mutation><arg name="valor1"></arg><arg name="otroValor"></arg></mutation><field name="NAME">hacer algo con parametros</field><comment pinned="false" h="80" w="160">Un comentario para el procedimiento</comment></block></xml>',
-  `/**
+  `/*
  * Un comentario para el procedimiento
  */
 procedure HacerAlgoConParametros(valor1, otroValor) {

--- a/test/generator_test.js
+++ b/test/generator_test.js
@@ -40,9 +40,9 @@ suite('gs-element-blockly_generator', function() {
 
   gsTestCode('Procedimiento',
   '<xml xmlns="http://www.w3.org/1999/xhtml"><block type="procedures_defnoreturn"><mutation><arg name="valor1"></arg><arg name="otroValor"></arg></mutation><field name="NAME">hacer algo con parametros</field><comment pinned="false" h="80" w="160">Un comentario para el procedimiento</comment></block></xml>',
-  `/*
- * Un comentario para el procedimiento
- */
+  `//
+// Un comentario para el procedimiento
+//
 procedure HacerAlgoConParametros(valor1, otroValor) {
 }\n`);
 


### PR DESCRIPTION
GW no anda con /** por alguna razón.

Mientras tanto podemos usar esto para seguir con la integración y cuando haga el cambio en el parser que arregle eso los volvemos a dejar como estaban :)