### PR TITLE
BOOM: Reemplazando barra comilla por comilla simple

### DIFF
--- a/js/gobstones-language-generator.js
+++ b/js/gobstones-language-generator.js
@@ -281,7 +281,7 @@ Blockly.GobstonesLanguage.BOOM = function(block) {
 		sinComillasEnvolventes = desc.substring(1,desc.length-1);
 	}
 
-  return 'BOOM("' + sinComillasEnvolventes.replace(/"/g, '\\"') + '")\n';
+  return 'BOOM("' + sinComillasEnvolventes.replace(/"/g, "'") + '")\n';
 };
 Blockly.GobstonesLanguage.ColorSelector = literalSelectorBlockCodeGenerator('Color');
 Blockly.GobstonesLanguage.DireccionSelector = literalSelectorBlockCodeGenerator('Direccion');

--- a/test/suiteCommandsGenerators.js
+++ b/test/suiteCommandsGenerators.js
@@ -29,11 +29,11 @@ gsSuite('Generadores de Comandos', function() {
 
   gsTestCode('BOOM sanitiza comillas',
     '<xml xmlns="http://www.w3.org/1999/xhtml"><block type="BOOM"><field name="boomDescription">Chor"lito</field></block></xml>',
-    `BOOM("Chor\\"lito")\n`);
+    `BOOM("Chor'lito")\n`);
 
   gsTestCode('BOOM omite comillas iniciales y finales',
     '<xml xmlns="http://www.w3.org/1999/xhtml"><block type="BOOM"><field name="boomDescription">""Chor"lito"</field></block></xml>',
-    `BOOM("\\"Chor\\"lito")\n`);
+    `BOOM("\\"Chor'lito")\n`);
 
   gsTestCode('Procedimiento',
   '<xml xmlns="http://www.w3.org/1999/xhtml"><block type="procedures_defnoreturn"><mutation><arg name="valor1"></arg><arg name="otroValor"></arg></mutation><field name="NAME">hacer algo con parametros</field><comment pinned="false" h="80" w="160">Un comentario para el procedimiento</comment></block></xml>',


### PR DESCRIPTION
Luego de la discusión de https://github.com/Program-AR/gs-element-blockly/issues/57, al meterme en el código del intérprete llegué a que parsear el `\"` no era tan fácil como creía, así que por ahora hice que las reemplace por comillas simples.