### PR TITLE
Fixing wrong VERSION namespace

### DIFF
--- a/gem/lib/gobstones/blockly/version.rb
+++ b/gem/lib/gobstones/blockly/version.rb
@@ -1,5 +1,5 @@
 module Gobstones
-  module Board
+  module Blockly
     VERSION = "0.6.7"
   end
 end


### PR DESCRIPTION
Fixing typo: changing `Gobstones::Board` to `Gobstones::Blockly`. It is necessary to avoid defined-twice warnings when using with `Gobstones::Board`:

```
/home/franco/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/gobstones-blockly-0.6.0/lib/gobstones/blockly/version.rb:3: warning: already initialized constant Gobstones::Board::VERSION
/home/franco/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/gobstones-board-1.8.6/lib/gobstones/board/version.rb:3: warning: previous definition of VERSION was here
```