### PR TITLE
moving inclusion scripts before Polymer code

### DIFF
--- a/gs-element-blockly.html
+++ b/gs-element-blockly.html
@@ -112,6 +112,17 @@ Example:
     </xml>
   </template>
 
+  <script src="../blockly-package/blockly_compressed.js"></script>
+  <script src="../blockly-package/blocks_compressed.js"></script>
+  <script src="../blockly-package/es.js"></script>
+  <script src="../proceds-blockly/proceds-blockly-original.js"></script>
+  <script src="../proceds-blockly/proceds-blockly.js"></script>
+  <script>initProcedsBlockly("Statement");</script>
+  <script src="js/gobstones-blocks.js"></script>
+  <script src="js/gobstones-language-generator.js"></script>
+  <script src="js/block-aliases.js"></script>
+  <script src="js/errors.js"></script>
+  
   <script>
     Polymer({
       is: 'gs-element-blockly',
@@ -901,15 +912,4 @@ Example:
       }
     });
   </script>
-
-  <script src="../blockly-package/blockly_compressed.js"></script>
-  <script src="../blockly-package/blocks_compressed.js"></script>
-  <script src="../blockly-package/es.js"></script>
-  <script src="../proceds-blockly/proceds-blockly-original.js"></script>
-  <script src="../proceds-blockly/proceds-blockly.js"></script>
-  <script>initProcedsBlockly("Statement");</script>
-  <script src="js/gobstones-blocks.js"></script>
-  <script src="js/gobstones-language-generator.js"></script>
-  <script src="js/block-aliases.js"></script>
-  <script src="js/errors.js"></script>
 </dom-module>


### PR DESCRIPTION
@rodri042 I don't know if this change breaks something for you, but when using gs-element-blockly from another source and navigating between pages, i'm getting` Blockly is undefined` and changing the inclusion order fixes it